### PR TITLE
Assign a default user if job was run by scheduler

### DIFF
--- a/nautobot_chatops_ansible/worker.py
+++ b/nautobot_chatops_ansible/worker.py
@@ -151,7 +151,7 @@ def get_jobs(dispatcher, count):
             (
                 entry["id"],
                 entry["name"],
-                entry["summary_fields"]["created_by"]["username"],
+                entry["summary_fields"].get("created_by", {}).get("username", "Scheduler"),
                 entry["created"],
                 entry["finished"],
                 entry["status"],


### PR DESCRIPTION
Fixes #28 

When a job is run by the scheduler, the job entry doesn't contain a `created_by` key. This fix sets a default user of  "Scheduler" if the job was not created by a user.

```text
Job ID              Name                 User                Created                      Finished              Status  
========================================================================================================================
193397   UBNT - Cloudflare DNS         Scheduler   2021-08-18T20:45:27.850414Z   2021-08-18T20:45:43.989341   successful
                                                                                 Z                                      
193395   UBNT - Cloudflare DNS         Scheduler   2021-08-18T20:40:27.512786Z   2021-08-18T20:40:40.108166   successful
                                                                                 Z                                      
193393   UBNT - Cloudflare DNS         Scheduler   2021-08-18T20:35:27.115163Z   2021-08-18T20:35:39.718745   successful
                                                                                 Z                                      
193391   UBNT - Cloudflare DNS         Scheduler   2021-08-18T20:30:26.729217Z   2021-08-18T20:30:41.015863   successful
                                                                                 Z                                      
193389   UBNT - Cloudflare DNS         Scheduler   2021-08-18T20:25:16.682044Z   2021-08-18T20:25:29.294439   successful
                                                                                 Z                                      
193387   UBNT - Cloudflare DNS         Scheduler   2021-08-18T20:20:06.729267Z   2021-08-18T20:20:23.684082   successful
                                                                                 Z                                      
193385   UBNT - Cloudflare DNS         Scheduler   2021-08-18T20:15:06.337740Z   2021-08-18T20:15:19.070625   successful
                                                                                 Z                                      
193384   Network - Copy Backups to     admin       2021-08-18T20:13:59.332088Z   2021-08-18T20:14:03.431082   successful
         NFS                                                                     Z                                      
193383   Network - Backup              admin       2021-08-18T20:13:50.152897Z   2021-08-18T20:13:59.128981   successful
                                                                                 Z                                      
193380   UBNT - Cloudflare DNS         Scheduler   2021-08-18T20:10:05.945449Z   2021-08-18T20:10:18.653012   successful
                                                                                 Z                                      
```